### PR TITLE
bump version with new dependencies, ready for exist V5

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -13,37 +13,41 @@
 	<tag>exist</tag>
 	<category id="libs">Libraries</category>
 	<category id="exist">eXist extensions</category>
-	<dependency processor="http://exist-db.org" semver-min="2.3.0" />
+	<dependency processor="http://exist-db.org" semver-min="5.0.0" />
 	<dependencySets>
 		<dependencySet>
 			<groupId>org.expath.exist</groupId>
-			<artifactId>ft-client</artifactId>
-			<version>1.1.5</version>
+			<artifactId>exist-ft-client</artifactId>
+			<version>2.0.0</version>
 		</dependencySet>
 		<dependencySet>
 			<groupId>ro.kuberam.libs.java</groupId>
 			<artifactId>ft-client</artifactId>
-			<version>1.1.2</version>
+			<version>2.0.0</version>
 		</dependencySet>
 		<dependencySet>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch</artifactId>
 			<version>0.1.51</version>
 		</dependencySet>
+
+                <!-- Dependencies of ft-client-java-lib -->
+		<dependencySet>
+			<groupId>commons-net</groupId>
+			<artifactId>commons-net</artifactId>
+			<version>3.3</version>
+		</dependencySet>
+		<dependencySet>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>1.3.2</version>
+		</dependencySet>
 	</dependencySets>
 
 	<components>
 		<resource>
-			<public-uri>http://exist-db.org/xquery/jms</public-uri>
-			<file>urn:java:class:org.exist.jms.xquery.JmsModule</file>
-		</resource>
-		<resource>
-			<public-uri>http://exist-db.org/xquery/messaging</public-uri>
-			<file>urn:java:class:org.exist.jms.xquery.MessagingModule</file>
-		</resource>
-		<resource>
-			<public-uri>http://exist-db.org/xquery/replication</public-uri>
-			<file>urn:java:class:org.exist.jms.xquery.ReplicationModule</file>
+			<public-uri>http://expath.org/ns/ft-client</public-uri>
+                        <file>org.expath.exist.ftclient.ExistExpathFTClientModule</file>
 		</resource>
 	</components>
 </package>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,11 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>ro.kuberam.xars</groupId>
-		<artifactId>base</artifactId>
-		<version>0.0.5</version>
-	</parent>
 
+        <groupId>org.expath.exist</groupId>
 	<artifactId>ft-client</artifactId>
-	<version>1.1.6</version>
+	<version>2.0.0</version>
+        <name>eXist XAR for EXPath File Transfer Client module</name>
 	<packaging>pom</packaging>
 	<url>http://kuberam.ro/specs/expath/ft-client/ft-client.html</url>
 
@@ -53,8 +50,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.expath.exist</groupId>
-			<artifactId>ft-client</artifactId>
-			<version>1.1.5</version>
+			<artifactId>exist-ft-client</artifactId>
+			<version>2.0.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
`for m in ft-client-java-lib ft-client-exist-java-lib expath-ft-client-exist-lib-xar ; do cd $m ; mvn clean install ; cd - ; done` build all the jar and xar file.

I can't get stuff for the associated demo package but perform a very basic test using next docker run :
`docker run -it -p 8081:8080 -v $PWD/expath-ft-client-exist-lib-xar/target/expath-ft-client-exist-lib-2.0.0.xar:/exist/autodeploy/expath-ft-client-exist-lib-2.0.0.xar --rm existdb/existdb:latest
`
 and calling :
```
xquery version "3.1";
import module namespace ft-client="http://expath.org/ns/ft-client";
ft-client:connect(xs:anyURI('ftp://ftp.de.debian.org/debian/'))
```

Pom.xml modifications are maybe too much for you, but this was enough on my side to get to goal.

Thx for this module!